### PR TITLE
Proton: Make text on accented backgrounds readable

### DIFF
--- a/proton/rose-pine.user.css
+++ b/proton/rose-pine.user.css
@@ -267,5 +267,11 @@
       background-color: var(--navigation-current-item-background-color);
       color: var(--email-item-unread-text-color);
     }
+    
+    /* makes text readable on accented backgrounds */
+    .item-is-selected,
+    .button-solid-norm {
+      color: @base;
+    }
   }
 }


### PR DESCRIPTION
![buttonscreenshot3](https://github.com/rose-pine/userstyles/assets/10424281/33a7e43f-533f-4bb2-a864-795cdd03793e)
![buttonscreenshot2](https://github.com/rose-pine/userstyles/assets/10424281/68d41809-d38b-45b0-ad18-b0d8ea1eda28)
![emailscreenshotdawn](https://github.com/rose-pine/userstyles/assets/10424281/279ecf60-f9bf-4086-9fd2-1d4685376f60)
![buttonscreenshot1](https://github.com/rose-pine/userstyles/assets/10424281/c249c6dc-943a-484f-b9ca-636c48286240)
![buttonscreenshot0](https://github.com/rose-pine/userstyles/assets/10424281/8169ee9c-b197-406c-b345-d75877224358)
![emailscreenshot](https://github.com/rose-pine/userstyles/assets/10424281/4949617b-53b5-4a81-bfe4-e9ed0a4357d6)

This change makes these elements readable by maximising contrast with the accented background. Should look good with any combo of accent/flavour, but lmk if there are any issues.