### PR TITLE
Change background colour of the proton badge when it's selected for readability

### DIFF
--- a/styles/proton/rose-pine.user.css
+++ b/styles/proton/rose-pine.user.css
@@ -273,5 +273,10 @@
 		.button-solid-norm {
 			color: @base;
 		}
+
+        /* the "Official" badge; setting the background to overlay makes it readable when selected */
+        .label-proton-badge--selected {
+            background-color: @overlay;
+        }
 	}
 }


### PR DESCRIPTION
With the change:

![image](https://github.com/rose-pine/userstyles/assets/10424281/6c3014b8-dd7c-4794-80a8-3bf21928e0fc)

Before the change:

![image](https://github.com/rose-pine/userstyles/assets/10424281/770d4102-1c22-4a61-bbfc-f777679ce471)

I've tried out different flavours and accents and this change seems to work well with all combinations.